### PR TITLE
Adding kick feature

### DIFF
--- a/lib/sorteios_web/live/room_live/show.html.heex
+++ b/lib/sorteios_web/live/room_live/show.html.heex
@@ -120,7 +120,7 @@
   <div class="mt-6">
     <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <%= for user <- @users do %>
-        <.user_block user={user} show_email?={@admin?} />
+        <.user_block user={user} show_email?={@admin?} can_kick?={@admin? and user.email != @current_user.email} />
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
## Background

Added a feature where the admin can kick people from the room.

## Approach

The admin can kick any person except themself, after a confirmation dialog. When kicking a person, the person is redirected to the main page and a message appears notifying them of the kicking.

## Known issues

The kicked person can simply open a new tab and join the room again. I wasn't able to implement `clear_session` inside of the kick event. Even when clearing session though, it is possible to log in back again anyway. A workaround would be to kick an undesired person right before the draw, I guess. :P