### PR TITLE
Adding chances to win and user count

### DIFF
--- a/lib/sorteios_web/live/room_live/show.ex
+++ b/lib/sorteios_web/live/room_live/show.ex
@@ -160,13 +160,13 @@ defmodule SorteiosWeb.RoomLive.Show do
       end)
       |> Enum.dedup_by(& &1[:email])
 
-    eligible_users = length(users) - 1
-    chance = compute_chance(eligible_users)
+    eligible_users_count = length(users) - 1
+    winning_chance = compute_chance(eligible_users_count)
 
     socket
     |> assign(:users, users)
-    |> assign(:eligible_users, eligible_users)
-    |> assign(:chance, chance)
+    |> assign(:eligible_users_count, eligible_users_count)
+    |> assign(:winning_chance, winning_chance)
   end
 
   def filter_available_prizes(socket) do

--- a/lib/sorteios_web/live/room_live/show.ex
+++ b/lib/sorteios_web/live/room_live/show.ex
@@ -143,6 +143,14 @@ defmodule SorteiosWeb.RoomLive.Show do
     |> filter_available_prizes()
   end
 
+  def compute_chance(users_length) do
+    if users_length > 0 do
+      100/users_length
+    else
+      0.0
+    end
+  end
+
   def reload_users(socket) do
     users =
       Presence.list(topic(socket))
@@ -152,8 +160,13 @@ defmodule SorteiosWeb.RoomLive.Show do
       end)
       |> Enum.dedup_by(& &1[:email])
 
+    eligible_users = length(users) - 1
+    chance = compute_chance(eligible_users)
+
     socket
     |> assign(:users, users)
+    |> assign(:eligible_users, eligible_users)
+    |> assign(:chance, chance)
   end
 
   def filter_available_prizes(socket) do

--- a/lib/sorteios_web/live/room_live/show.html.heex
+++ b/lib/sorteios_web/live/room_live/show.html.heex
@@ -208,8 +208,8 @@
               <h3 class="text-lg font-medium leading-6 text-gray-900">Prize drawing</h3>
 
               <%= if Enum.any?(@available_prizes) do %>
-                <p class="text-sm font-medium text-gray-900">Eligible users: <%= @eligible_users %></p>
-                <p class="text-sm font-medium text-gray-900">Chances: <%= :erlang.float_to_binary(@chance, [decimals: 2]) %>%</p>
+                <p class="text-sm font-medium text-gray-900">Eligible users: <%= @eligible_users_count %></p>
+                <p class="text-sm font-medium text-gray-900">Chances: <%= :erlang.float_to_binary(@winning_chance, [decimals: 2]) %>%</p>
                 <button
                   phx-click="pick_a_random_person"
                   class="block w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:my-2 sm:w-auto sm:text-sm"

--- a/lib/sorteios_web/live/room_live/show.html.heex
+++ b/lib/sorteios_web/live/room_live/show.html.heex
@@ -208,6 +208,8 @@
               <h3 class="text-lg font-medium leading-6 text-gray-900">Prize drawing</h3>
 
               <%= if Enum.any?(@available_prizes) do %>
+                <p class="text-sm font-medium text-gray-900">Eligible users: <%= @eligible_users %></p>
+                <p class="text-sm font-medium text-gray-900">Chances: <%= :erlang.float_to_binary(@chance, [decimals: 2]) %>%</p>
                 <button
                   phx-click="pick_a_random_person"
                   class="block w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:my-2 sm:w-auto sm:text-sm"


### PR DESCRIPTION
## Background

I thought it would be cool to have the number of users eligible for the draw and the chances of each one winning.

## Approach

Made two more variables to count how many users are and a function to calculate chances.

## Considerations

Right now, this information is only available for the admin, but it would be cool if this was available for everyone. For now, I've decided against it because it could cause some confusion on people seeing a number lesser than the number of people at the room. Let me know what you think and I will follow accordingly.