### PR TITLE
Removed unnecessary $

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -31,10 +31,10 @@ const hooks = {
       const { inputSelector } = this.el.dataset;
       this.el.addEventListener("click", (ev) => {
         ev.preventDefault();
-        const $targetInput = document.querySelector(inputSelector);
-        $targetInput.select();
-        $targetInput.setSelectionRange(0, 99999);
-        navigator.clipboard.writeText($targetInput.value);
+        const targetInput = document.querySelector(inputSelector);
+        targetInput.select();
+        targetInput.setSelectionRange(0, 99999);
+        navigator.clipboard.writeText(targetInput.value);
       });
     },
   }


### PR DESCRIPTION
This might've been what was causing the issues. There's no need to call $ before a js variable when defining it or when calling it, unless you're using jquery, which wouldn't require for that when initializing the variable.