### PR TITLE
Tolerate users who left for 30 seconds and then remove them from the list

### DIFF
--- a/lib/sorteios_web/live/room_live/show.ex
+++ b/lib/sorteios_web/live/room_live/show.ex
@@ -131,6 +131,10 @@ defmodule SorteiosWeb.RoomLive.Show do
     {:noreply, reload_prizes(socket)}
   end
 
+  def handle_info("remove_disconnected_users", socket) do
+    {:noreply, reload_users(socket)}
+  end
+
   defp topic(%{assigns: %{room: room}}), do: topic(room)
   defp topic(%Room{id: id}), do: "room:#{id}"
 
@@ -179,6 +183,26 @@ defmodule SorteiosWeb.RoomLive.Show do
         |> List.first()
       end)
       |> Enum.dedup_by(& &1[:email])
+
+    disconnected_users =
+      socket.assigns.users
+      |> Enum.filter(fn user ->
+        not Enum.any?(users, &(&1[:email] == user[:email]))
+      end)
+      |> Enum.map(fn user ->
+        if Map.get(user, :disconnected_at, nil) == nil do
+          Map.put(user, :disconnected_at, NaiveDateTime.utc_now)
+        else
+          user
+        end
+      end)
+      |> Enum.filter(&(NaiveDateTime.diff(NaiveDateTime.utc_now, &1[:disconnected_at], :millisecond) < 30_000))
+
+    if Enum.count(disconnected_users) > 0 do
+      Process.send_after(self(), "remove_disconnected_users", 30_100)
+    end
+
+    users = users ++ disconnected_users
 
     eligible_users_count = length(users) - 1
     winning_chance = compute_chance(eligible_users_count)


### PR DESCRIPTION
Close #30 

It's simple but not perfect solution. For more accurate sync between different LiveViews we need to create one GenServer for each room and run it when one or more LiveView processes for given room exists.